### PR TITLE
Sbloccato il controllo della simulazione

### DIFF
--- a/MMR_Simulator_DLL/Car.hpp
+++ b/MMR_Simulator_DLL/Car.hpp
@@ -1,6 +1,7 @@
 #ifndef CAR_HPP
 #define CAR_HPP
 
+#include "PhysicsEngine.hpp"
 #include <acs_cosim/interface/CarControls.hpp>
 #include <acs_cosim/interface/Utils.hpp>
 
@@ -8,7 +9,8 @@ using namespace acs_cosim::interface::data;
 
 class Car {
 public:							// Offset
-    char undefined0[0x140];
+    char undefined0[0x138];
+	PhysicsEngine* ksPhysics;	// 0x138
 	CarControls controls;		// 0x140
     char undefined1[0x172];
 	float mass;					// 0x1e0

--- a/MMR_Simulator_DLL/CarAvatar.hpp
+++ b/MMR_Simulator_DLL/CarAvatar.hpp
@@ -1,0 +1,6 @@
+#ifndef CAR_AVATAR_HPP
+#define CAR_AVATAR_HPP
+
+struct CarAvatar;
+
+#endif // !CAR_AVATAR_HPP

--- a/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
+++ b/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
@@ -161,6 +161,7 @@
     <ClInclude Include="MMRSimulatorDll.h" />
     <ClInclude Include="Parameters.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="PhysicsEngine.hpp" />
     <ClInclude Include="Sim.hpp" />
     <ClInclude Include="UDPCommandListener.hpp" />
     <ClInclude Include="winapi_helpers.hpp" />

--- a/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
+++ b/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
@@ -152,6 +152,8 @@
     <ClInclude Include="MMRSimulatorDll.h" />
     <ClInclude Include="Parameters.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="Sim.hpp" />
+    <ClInclude Include="UDPCommandListener.hpp" />
     <ClInclude Include="winapi_helpers.hpp" />
   </ItemGroup>
   <ItemGroup>

--- a/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
+++ b/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
@@ -122,6 +122,10 @@
       <AdditionalLibraryDirectories>C:\Program Files (x86)\acs_cosim_interface\lib;$(ProjectDir)..\Dependencies\Detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>acs_cosim_interface_server.lib;detours.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent />
+    <PostBuildEvent>
+      <Command>xcopy /y /d "$(ProjectDir)x64\$(Configuration)\MMR_Simulator_DLL.dll" "C:\Games\mmr_assettocorsa\assettocorsa"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -145,6 +149,10 @@
       <AdditionalLibraryDirectories>C:\Program Files (x86)\acs_cosim_interface\lib;$(ProjectDir)..\Dependencies\Detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>acs_cosim_interface_server.lib;detours.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent />
+    <PostBuildEvent>
+      <Command>xcopy /y /d "$(ProjectDir)x64\$(Configuration)\MMR_Simulator_DLL.dll" "C:\Games\mmr_assettocorsa\assettocorsa"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Car.hpp" />

--- a/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
+++ b/MMR_Simulator_DLL/MMR_Simulator_DLL.vcxproj
@@ -156,6 +156,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Car.hpp" />
+    <ClInclude Include="CarAvatar.hpp" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="MMRSimulatorDll.h" />
     <ClInclude Include="Parameters.h" />

--- a/MMR_Simulator_DLL/PhysicsEngine.hpp
+++ b/MMR_Simulator_DLL/PhysicsEngine.hpp
@@ -1,0 +1,11 @@
+#ifndef PHYSICS_ENGINE_HPP
+#define PHYSICS_ENGINE_HPP
+
+struct PhysicsEngine {
+	char undefined0[0x20];
+	double physicsTime;	// 0x20
+	char undefined1[0xd0];
+	double gameTime;	// 0xf8
+};
+
+#endif // !PHYSICS_ENGINE_HPP

--- a/MMR_Simulator_DLL/Sim.hpp
+++ b/MMR_Simulator_DLL/Sim.hpp
@@ -1,0 +1,7 @@
+#ifndef SIM_HPP
+#define SIM_HPP
+
+struct Sim;
+
+#endif // !SIM_HPP
+

--- a/MMR_Simulator_DLL/Sim.hpp
+++ b/MMR_Simulator_DLL/Sim.hpp
@@ -4,4 +4,3 @@
 struct Sim;
 
 #endif // !SIM_HPP
-

--- a/MMR_Simulator_DLL/UDPCommandListener.hpp
+++ b/MMR_Simulator_DLL/UDPCommandListener.hpp
@@ -1,0 +1,12 @@
+#ifndef UDP_COMMAD_LISTENER_HPP
+#define UDP_COMMAD_LISTENER_HPP
+
+#include "Sim.hpp"
+
+struct UDPCommandListener {
+	char undefined[88];
+	Sim* sim;
+	unsigned long sok;
+};
+
+#endif // UDP_COMMAD_LISTENER_HPP

--- a/MMR_Simulator_DLL/dllmain.cpp
+++ b/MMR_Simulator_DLL/dllmain.cpp
@@ -104,8 +104,12 @@ void hookedCarPollControls(Car* car, float period) {
 		// Get and send vehicle state
 		CarPhysicsState cps;
 		getCarPhysicsState(car, &cps);
-		VehicleStateMsg vehicle_state_msg(cps);
-		acs_server.send_message(&vehicle_state_msg);
+
+		VehicleState vehicleState(cps);
+		vehicleState.simulationTime = car->ksPhysics->physicsTime;
+
+		VehicleStateMsg vehicleStateMsg(vehicleState);
+		acs_server.send_message(&vehicleStateMsg);
 	} while (!advance);
 }
 

--- a/MMR_Simulator_DLL/dllmain.cpp
+++ b/MMR_Simulator_DLL/dllmain.cpp
@@ -53,7 +53,6 @@ static Parameters params;
 void hookedCommandListenerUpdateFunction(UDPCommandListener* localCommandListener, float period) {
 	if (commandListener == nullptr) {
 		commandListener = localCommandListener;
-		std::cerr << "Found command listener" << std::endl;
 
 		// Start the simulation
 		if (originalSimStartGameFunction) {
@@ -104,12 +103,9 @@ void hookedCarPollControls(Car* car, float period) {
 		// Get and send vehicle state
 		CarPhysicsState cps;
 		getCarPhysicsState(car, &cps);
-
-		VehicleState vehicleState(cps);
-		vehicleState.simulationTime = car->ksPhysics->physicsTime;
-
-		VehicleStateMsg vehicleStateMsg(vehicleState);
-		acs_server.send_message(&vehicleStateMsg);
+		SimulationState simulationState(car->ksPhysics->physicsTime, cps);
+		SimulationStateMsg simulationStateMsg(simulationState);
+		acs_server.send_message(&simulationStateMsg);
 	} while (!advance);
 }
 


### PR DESCRIPTION
Ora la DLL è in grado di controllare alcune funzioni di base del simulatore:
- avvio automatico della simulazione (non più necessario premere il pulsante "Start")
- possibilità di resettare posizione e stato della macchina con il messaggio RESET
- ricezione del tempo di simulazione